### PR TITLE
Fix typos in schema.md

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -147,13 +147,13 @@ It uses custom extensions with the standard `X-` prefix.
 - Custom extensions preserve institutional data for CIRED-aware systems
 - Fallback behavior: Non-CIRED systems show standard contact info
 
-### Versionning
+### Versioning
 - Scraping scripts should hash the contents and set the `UID` property accordingly.
 - Scraping scripts include their name in `PRODID` property.
 - Use repeated `SOURCE` property to link to original public pages scrapped.
 
 ### Privacy & Security
-- Scraping scripts set visiblity to Admin-only
+- Scraping scripts set visibility to Admin-only
 - Only merge vCard variants with the same visibility level.
 - Respect visibility settings when exporting
 


### PR DESCRIPTION
## Summary
- correct spelling for `Versioning`
- fix typo in visibility section

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684996f6c7a88325b12ac15090337fb3